### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/lib/pronto/json/version.rb
+++ b/lib/pronto/json/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module Json
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.1.2'.freeze
   end
 end

--- a/pronto-json.gemspec
+++ b/pronto-json.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'pronto', '~> 0.6.0'
+  spec.add_dependency 'pronto', '~> 0.7.0'
   spec.add_dependency 'oj', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
Just a small PR that will make this gem `pronto 0.7.0` compatible