### PR TITLE
Update dependency on oj

### DIFF
--- a/pronto-json.gemspec
+++ b/pronto-json.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'pronto', '~> 0.9.0'
-  spec.add_dependency 'oj', '~> 2.0'
+  spec.add_dependency 'oj', '~> 3.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I'm using pronto-json as a test suite dependency in one of my Rails applications, but it's causing me to be locked into a really old version of the `oj` gem. `oj` doesn't really break compatibility with their releases, so it should be safe to set a newer dependency (or no specific version dependency at all.